### PR TITLE
feat(app.sh): make log output less verbose

### DIFF
--- a/app/app.sh
+++ b/app/app.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 # Downloading Link provided
-wget $LINK/download
+# The option --progress=bar:force:noscroll makes the log output less verbose
+# While the progressbar is displayed only one line is added for it in the logs
+wget --progress=bar:force:noscroll $LINK/download
 mv download download.zip
 unzip -q download.zip -d /odtp/odtp-output


### PR DESCRIPTION
add option --progress=bar:force:noscroll to wget:
this makes the log output less verbose: while the progressbar is displayed only one line is added for it in the log